### PR TITLE
Add support for InfluxData Cloud

### DIFF
--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -881,8 +881,9 @@ private logger(msg, level = "debug") {
  *  Encode credentials for HTTP Basic authentication.
  **/
 private encodeCredentialsBasic(username, password) {
-	def rawString = "Basic " + "${username}:${password}"
-    return rawString.bytes.encodeBase64().toString()
+    def creds = "${username}:${password}"
+    creds = creds.bytes.encodeBase64().toString()
+    return "Basic ${creds}"
 }
 
 /**

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -40,94 +40,95 @@ definition(
 preferences {
     page(name: "setupMain", title: " ", install: true, uninstall: true) {
 
-    section("General:") {
-        //input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true
-        
-        href(name: "href",
-                 title: "Connection Settings",
-                 description: prefDatabaseHost==null?"Configure database connection parameters":prefDatabaseHost,
-                 required: true,
-                 page: "connectionPage")
-        
-        input (
-        	name: "configLoggingLevelIDE",
-        	title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
-        	type: "enum",
-        	options: [
-        	    "0" : "None",
-        	    "1" : "Error",
-        	    "2" : "Warning",
-        	    "3" : "Info",
-        	    "4" : "Debug",
-        	    "5" : "Trace"
-        	],
-        	defaultValue: "3",
-            displayDuringSetup: true,
-        	required: false
-        )
-        
-    }
+        section("General:") {
+            //input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true
+
+            href(
+                name: "href",
+                title: "Connection Settings",
+                description: prefDatabaseHost==null?"Configure database connection parameters":prefDatabaseHost,
+                required: true,
+                page: "connectionPage"
+            )
+
+            input (
+                name: "configLoggingLevelIDE",
+                title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
+                type: "enum",
+                options: [
+                    "0" : "None",
+                    "1" : "Error",
+                    "2" : "Warning",
+                    "3" : "Info",
+                    "4" : "Debug",
+                    "5" : "Trace"
+                ],
+                defaultValue: "3",
+                displayDuringSetup: true,
+                required: false
+            )
+
+        }
 
     
-    section("Polling / Write frequency:") {
-        input "prefSoftPollingInterval", "number", title:"Soft-Polling interval (minutes)", defaultValue: 10, required: true
+        section("Polling / Write frequency:") {
+            input "prefSoftPollingInterval", "number", title:"Soft-Polling interval (minutes)", defaultValue: 10, required: true
 
-        input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
-        	options: ["1",  "5", "10", "15"]
-    }
-    
-    section("System Monitoring:") {
-        input "prefLogModeEvents", "bool", title:"Log Mode Events?", defaultValue: true, required: true
-        input "prefLogHubProperties", "bool", title:"Log Hub Properties?", defaultValue: true, required: true
-        input "prefLogLocationProperties", "bool", title:"Log Location Properties?", defaultValue: true, required: true
-    }
-    
-    section("Devices To Monitor:") {
-        input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
-        input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
-        input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
-        input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
-        input "buttons", "capability.button", title: "Buttons", multiple: true, required: false
-        input "cos", "capability.carbonMonoxideDetector", title: "Carbon Monoxide Detectors", multiple: true, required: false
-        input "co2s", "capability.carbonDioxideMeasurement", title: "Carbon Dioxide Detectors", multiple: true, required: false
-        input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
-        input "consumables", "capability.consumable", title: "Consumables", multiple: true, required: false
-        input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
-        input "doorsControllers", "capability.doorControl", title: "Door Controllers", multiple: true, required: false
-        input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
-        input "humidities", "capability.relativeHumidityMeasurement", title: "Humidity Meters", multiple: true, required: false
-        input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
-        input "locks", "capability.lock", title: "Locks", multiple: true, required: false
-        input "motions", "capability.motionSensor", title: "Motion Sensors", multiple: true, required: false
-        input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
-        input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
-        input "phMeters", "capability.pHMeasurement", title: "pH Meters", multiple: true, required: false
-        input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
-        input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
-        input "pressures", "capability.sensor", title: "Pressure Sensors", multiple: true, required: false
-        input "shockSensors", "capability.shockSensor", title: "Shock Sensors", multiple: true, required: false
-        input "signalStrengthMeters", "capability.signalStrength", title: "Signal Strength Meters", multiple: true, required: false
-        input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
-        input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
-        input "soundSensors", "capability.soundSensor", title: "Sound Sensors", multiple: true, required: false
-		input "spls", "capability.soundPressureLevel", title: "Sound Pressure Level Sensors", multiple: true, required: false
-		input "switches", "capability.switch", title: "Switches", multiple: true, required: false
-        input "switchLevels", "capability.switchLevel", title: "Switch Levels", multiple: true, required: false
-        input "tamperAlerts", "capability.tamperAlert", title: "Tamper Alerts", multiple: true, required: false
-        input "temperatures", "capability.temperatureMeasurement", title: "Temperature Sensors", multiple: true, required: false
-        input "thermostats", "capability.thermostat", title: "Thermostats", multiple: true, required: false
-        input "threeAxis", "capability.threeAxis", title: "Three-axis (Orientation) Sensors", multiple: true, required: false
-        input "touchs", "capability.touchSensor", title: "Touch Sensors", multiple: true, required: false
-        input "uvs", "capability.ultravioletIndex", title: "UV Sensors", multiple: true, required: false
-        input "valves", "capability.valve", title: "Valves", multiple: true, required: false
-        input "volts", "capability.voltageMeasurement", title: "Voltage Meters", multiple: true, required: false
-        input "waterSensors", "capability.waterSensor", title: "Water Sensors", multiple: true, required: false
-        input "windowShades", "capability.windowShade", title: "Window Shades", multiple: true, required: false
-    }
+            input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
+                options: ["1",  "5", "10", "15"]
+        }
+
+        section("System Monitoring:") {
+            input "prefLogModeEvents", "bool", title:"Log Mode Events?", defaultValue: true, required: true
+            input "prefLogHubProperties", "bool", title:"Log Hub Properties?", defaultValue: true, required: true
+            input "prefLogLocationProperties", "bool", title:"Log Location Properties?", defaultValue: true, required: true
+        }
+
+        section("Devices To Monitor:") {
+            input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
+            input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
+            input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
+            input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
+            input "buttons", "capability.button", title: "Buttons", multiple: true, required: false
+            input "cos", "capability.carbonMonoxideDetector", title: "Carbon Monoxide Detectors", multiple: true, required: false
+            input "co2s", "capability.carbonDioxideMeasurement", title: "Carbon Dioxide Detectors", multiple: true, required: false
+            input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
+            input "consumables", "capability.consumable", title: "Consumables", multiple: true, required: false
+            input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
+            input "doorsControllers", "capability.doorControl", title: "Door Controllers", multiple: true, required: false
+            input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
+            input "humidities", "capability.relativeHumidityMeasurement", title: "Humidity Meters", multiple: true, required: false
+            input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
+            input "locks", "capability.lock", title: "Locks", multiple: true, required: false
+            input "motions", "capability.motionSensor", title: "Motion Sensors", multiple: true, required: false
+            input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
+            input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
+            input "phMeters", "capability.pHMeasurement", title: "pH Meters", multiple: true, required: false
+            input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
+            input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
+            input "pressures", "capability.sensor", title: "Pressure Sensors", multiple: true, required: false
+            input "shockSensors", "capability.shockSensor", title: "Shock Sensors", multiple: true, required: false
+            input "signalStrengthMeters", "capability.signalStrength", title: "Signal Strength Meters", multiple: true, required: false
+            input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
+            input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
+            input "soundSensors", "capability.soundSensor", title: "Sound Sensors", multiple: true, required: false
+            input "spls", "capability.soundPressureLevel", title: "Sound Pressure Level Sensors", multiple: true, required: false
+            input "switches", "capability.switch", title: "Switches", multiple: true, required: false
+            input "switchLevels", "capability.switchLevel", title: "Switch Levels", multiple: true, required: false
+            input "tamperAlerts", "capability.tamperAlert", title: "Tamper Alerts", multiple: true, required: false
+            input "temperatures", "capability.temperatureMeasurement", title: "Temperature Sensors", multiple: true, required: false
+            input "thermostats", "capability.thermostat", title: "Thermostats", multiple: true, required: false
+            input "threeAxis", "capability.threeAxis", title: "Three-axis (Orientation) Sensors", multiple: true, required: false
+            input "touchs", "capability.touchSensor", title: "Touch Sensors", multiple: true, required: false
+            input "uvs", "capability.ultravioletIndex", title: "UV Sensors", multiple: true, required: false
+            input "valves", "capability.valve", title: "Valves", multiple: true, required: false
+            input "volts", "capability.voltageMeasurement", title: "Voltage Meters", multiple: true, required: false
+            input "waterSensors", "capability.waterSensor", title: "Water Sensors", multiple: true, required: false
+            input "windowShades", "capability.windowShade", title: "Window Shades", multiple: true, required: false
+        }
     }
 
     page(name: "connectionPage")
-
 
 }
 
@@ -140,46 +141,42 @@ def connectionPage() {
 
             input "prefDatabasePort", "text", title: "Port", defaultValue: prefDatabaseTls?"443":"8086", required: false
             input (
-        	    name: "prefInfluxVer",
-            	title: "Influx Version",
-            	type: "enum",
-            	options: [
-            	    "1" : "v1.x",
-        	        "2" : "v2.x"
-            	],
-            	defaultValue: "0",
-                displayDuringSetup: true,
+                name: "prefInfluxVer",
+                title: "Influx Version",
+                type: "enum",
+                options: [
+                    "1" : "v1.x",
+                    "2" : "v2.x"
+                ],
+                defaultValue: "1",
                 submitOnChange: true,
-            	required: true
+                required: true
             )
             if (prefInfluxVer == "1") {
                 input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
-            }
-            if (prefInfluxVer == "2") {
+            } else if (prefInfluxVer == "2") {
                 input "prefOrg", "text", title: "Org", defaultValue: "", required: true
                 input "prefBucket", "text", title: "Bucket", defaultValue: "", required: true
             }          
             
             input (
-        	    name: "prefAuthType",
-            	title: "Authorization Type",
-            	type: "enum",
-            	options: [
-            	    "none" : "None",
-        	        "basic" : "Username / Password",
+                name: "prefAuthType",
+                title: "Authorization Type",
+                type: "enum",
+                options: [
+                    "none" : "None",
+                    "basic" : "Username / Password",
                     "token" : "Token"
-            	],
-            	defaultValue: "none",
-                displayDuringSetup: true,
+                ],
+                defaultValue: "none",
                 submitOnChange: true,
-            	required: true
+                required: true
             )
             
             if (prefAuthType == "basic") {
                 input "prefDatabaseUser", "text", title: "Username", defaultValue: "", required: false
                 input "prefDatabasePass", "text", title: "Password", defaultValue: "", required: false
-            }
-            if (prefAuthType == "token") {
+            } else if (prefAuthType == "token") {
                 input "prefDatabaseToken", "text", title: "Token", required: true
             }
         }


### PR DESCRIPTION
I wanted to quickly try out the Influx integration.  It looks like the free cloud offering is using InfluxDB v2.x.  This PR makes a handful of changes needed to support connecting to the cloud version:

- Connection preferences in its own dynamic sub-page
- Add support for TLS connections
- Make port optional.  For non-TLS the default remains the same.  For TLS it is 443
- Add support for v2.x which needs org and bucket instead of DB name
- Add additional "Token" auth type as used by cloud

I'm not familiar enough with InfluxDB to know if the token auth option makes sense for v1.x (or if Basic auth makes sense for 2.x) so I just made it configurable separately from version.

On the Hubitat side, I've not developed an HE app before, so it is possible I'm missing something here...a lot of this stuff is sort of undocumented so I just tried to follow the existing conventions.