### PR TITLE
This pull request includes the changes for InfluxDB Logger to enable output to InfluxDB2.x

### DIFF
--- a/PackageManifest.json
+++ b/PackageManifest.json
@@ -1,9 +1,10 @@
 {
   "packageName": "InfluxDB-Logger",
   "author": "Joshua Marker (tooluser)",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2019-04-07",
+  "releaseNotes": "1.1.1 Update to support InfluxDB2.x \n This update changes or adds various connectivity components to support Influxdb2.x \n After the upgrade open up InfluxDB Logger, click on the Connection Settings button, verify your connection informatoin and click done in the lower right corner twice.",
   "apps": [
     {
       "id": "119c9c44-e7af-46c0-bc44-dc4f6b175994",

--- a/PackageManifest.json
+++ b/PackageManifest.json
@@ -1,10 +1,9 @@
 {
   "packageName": "InfluxDB-Logger",
   "author": "Joshua Marker (tooluser)",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "minimumHEVersion": "2.1.9",
   "dateReleased": "2019-04-07",
-  "releaseNotes": "1.1.1 Update to support InfluxDB2.x \n This update changes or adds various connectivity components to support Influxdb2.x \n After the upgrade open up InfluxDB Logger, click on the Connection Settings button, verify your connection informatoin and click done in the lower right corner twice.",
   "apps": [
     {
       "id": "119c9c44-e7af-46c0-bc44-dc4f6b175994",

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -29,6 +29,7 @@
  *   2019-09-09 Caleb Morse     Support deferring writes and doing buld writes to influxdb
  *   2022-06-20 Denny Page      Remove nested sections for device selection
  *   2023-01-08 Denny Page      Address whitespace related lint issues. No functional changes.
+ *   2023-01-09 Craig		Added InfluxDb2.x support
  *****************************************************************************************************************/
 definition(
     name: "InfluxDB Logger",

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -58,12 +58,12 @@ def setupMain() {
             href(
             name: "href",
             title: "Connection Settings",
-            description: prefDatabaseHost==null?"Configure database connection parameters":prefDatabaseHost,
+            description : prefDatabaseHost == null ? "Configure database connection parameters" : prefDatabaseHost,
             required: true,
             page: "connectionPage"
             )
 
-            input (
+            input(
                 name: "configLoggingLevelIDE",
                 title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
                 type: "enum",
@@ -98,7 +98,7 @@ def setupMain() {
             input "accessAllAttributes", "bool", title:"Get Access To All Attributes?", defaultValue: false, required: true, submitOnChange: true
         }
 
-        if(!accessAllAttributes) {
+        if (!accessAllAttributes) {
             section("Devices To Monitor:", hideable:false,hidden:false) {
                 input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
                 input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
@@ -145,22 +145,22 @@ def setupMain() {
             section("Devices To Monitor:", hideable:false,hidden:false) {
                 input name: "allDevices", type: "capability.*", title: "Selected Devices", multiple: true, required: false, submitOnChange: true
             }
-            state.selectedAttr=[:]
+            state.selectedAttr = [:]
             settings.allDevices.each { deviceName ->
-                if(deviceName) {
+                if (deviceName) {
                     deviceId = deviceName.getId()
                     attr = deviceName.getSupportedAttributes().unique()
-                    if(attr) {
-                        state.options =[]
+                    if (attr) {
+                        state.options = []
                         index = 0
-                        attr.each {at->
+                        attr.each { at->
                             state.options[index] = "${at}"
-                            index = index+1
+                            index = index + 1
                         }
                         section("$deviceName", hideable: true) {
                             input name:"attrForDev$deviceId", type: "enum", title: "$deviceName", options: state.options, multiple: true, required: false, submitOnChange: true
                         }
-                        state.selectedAttr[deviceId] = settings["attrForDev"+deviceId]
+                        state.selectedAttr[deviceId] = settings["attrForDev" + deviceId]
                     }
                 }
             }
@@ -173,8 +173,8 @@ def connectionPage() {
         section {
             input "prefDatabaseHost", "text", title: "Host", defaultValue: "192.168.1.100", required: true
             input "prefDatabaseTls", "bool", title:"Use TLS?", defaultValue: false, required: true
-            input "prefDatabasePort", "text", title: "Port", defaultValue: prefDatabaseTls?"443":"8086", required: false
-            input (
+            input "prefDatabasePort", "text", title: "Port", defaultValue : prefDatabaseTls ? "443" : "8086", required : false
+            input(
                 name: "prefInfluxVer",
                 title: "Influx Version",
                 type: "enum",
@@ -192,7 +192,7 @@ def connectionPage() {
                 input "prefOrg", "text", title: "Org", defaultValue: "", required: true
                 input "prefBucket", "text", title: "Bucket", defaultValue: "", required: true
             }
-            input (
+            input(
                 name: "prefAuthType",
                 title: "Authorization Type",
                 type: "enum",
@@ -279,14 +279,14 @@ def updated() {
 
     state.uri = "";
     if (settings.prefDatabaseTls) {
-        state.uri += "https://";
+        state.uri += "https://"
     } else {
-        state.uri += "http://";
+        state.uri += "http://"
     }
     state.uri += settings.prefDatabaseHost;
 
     if (settings.prefDatabasePort != null) {
-        state.uri += ":"+settings.prefDatabasePort;
+        state.uri += ":"+settings.prefDatabasePort
     }
 
     if (settings?.prefInfluxVer == "1" || settings?.prefInfluxVer == null) {
@@ -745,7 +745,7 @@ def queueToInfluxDb(data) {
     int queueSize = 0
     try {
         mutex.acquire()
-        //if(!mutex.tryAcquire()) {
+        //if (!mutex.tryAcquire()) {
         //    logger("Error 1 in queueToInfluxDb","Warning")
         //    mutex.release()
         //}
@@ -774,7 +774,7 @@ def writeQueuedDataToInfluxDb() {
 
     try {
         mutex.acquire()
-        //if(!mutex.tryAcquire()) {
+        //if (!mutex.tryAcquire()) {
         //    logger("Error 1 in writeQueuedDataToInfluxDb","Warning")
         //    mutex.release()
         //}

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -82,14 +82,6 @@ def setupMain() {
     	    )
     	}
 
-/*    	section ("InfluxDB Database:") {
-	        input "prefDatabaseHost", "text", title: "Host", defaultValue: "192.168.1.100", required: true
-    	    input "prefDatabasePort", "text", title: "Port", defaultValue: "8086", required: true
-        	input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
-        	input "prefDatabaseUser", "text", title: "Username", required: false
-        	input "prefDatabasePass", "text", title: "Password", required: false
-    	} */
-
   	    section("Polling / Write frequency:") {
 	        input "prefSoftPollingInterval", "number", title:"Soft-Polling interval (minutes)", defaultValue: 10, required: true
 

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -209,11 +209,10 @@ def connectionPage() {
                 title: "Authorization Type",
                 type: "enum",
                 options: [
-                    "none" : "None",
                     "basic" : "Username / Password",
                     "token" : "Token"
                 ],
-                defaultValue: "none",
+                defaultValue: "basic",
                 submitOnChange: true,
                 required: true
             )

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -46,130 +46,188 @@ definition(
     @Field static java.util.concurrent.Semaphore mutex = new java.util.concurrent.Semaphore(1)
 
 preferences {
-    page(name: "newPage")
+      	page(name: "setupMain")
+        page(name: "connectionPage")
 }
 
 
-def newPage() {
-    dynamicPage(name: "newPage", title: "New Settings Page", install: true, uninstall: true) {
-        section("General:") {
-            //input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true
-            input(
-                name: "configLoggingLevelIDE",
-                title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
+def setupMain() {
+    dynamicPage(name: "setupMain", title: "New Settings Page", install: true, uninstall: true) {
+	    section("General:") {
+    	    //input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true
+            
+            href(
+                name: "href",
+                title: "Connection Settings",
+                description: prefDatabaseHost==null?"Configure database connection parameters":prefDatabaseHost,
+                required: true,
+                page: "connectionPage"
+            )
+            
+        	input (
+        		name: "configLoggingLevelIDE",
+        		title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
+        		type: "enum",
+        		options: [
+	        	    "0" : "None",
+    	    	    "1" : "Error",
+        		    "2" : "Warning",
+        		    "3" : "Info",
+        	    	"4" : "Debug",
+	        	    "5" : "Trace"
+    	    	],
+        		defaultValue: "3",
+            	displayDuringSetup: true,
+	        	required: false
+    	    )
+    	}
+
+/*    	section ("InfluxDB Database:") {
+	        input "prefDatabaseHost", "text", title: "Host", defaultValue: "192.168.1.100", required: true
+    	    input "prefDatabasePort", "text", title: "Port", defaultValue: "8086", required: true
+        	input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
+        	input "prefDatabaseUser", "text", title: "Username", required: false
+        	input "prefDatabasePass", "text", title: "Password", required: false
+    	} */
+
+  	    section("Polling / Write frequency:") {
+	        input "prefSoftPollingInterval", "number", title:"Soft-Polling interval (minutes)", defaultValue: 10, required: true
+
+    	    input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
+        		options: ["1",  "2", "3", "4", "5", "10", "15"]
+    	}
+
+	    section("System Monitoring:") {
+    	    input "prefLogModeEvents", "bool", title:"Log Mode Events?", defaultValue: true, required: true
+        	input "prefLogHubProperties", "bool", title:"Log Hub Properties?", defaultValue: true, required: true
+        	input "prefLogLocationProperties", "bool", title:"Log Location Properties?", defaultValue: true, required: true
+    	}
+
+		section("Input Format Preference:") {
+			input "accessAllAttributes", "bool", title:"Get Access To All Attributes?", defaultValue: false, required: true, submitOnChange: true
+		}
+
+		if(!accessAllAttributes)
+		{
+	       	section("Devices To Monitor:", hideable:false,hidden:false) {
+    	 	  	input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
+       			input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
+       			input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
+       			input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
+	       		input "buttons", "capability.button", title: "Buttons", multiple: true, required: false
+    	  		input "cos", "capability.carbonMonoxideDetector", title: "Carbon Monoxide Detectors", multiple: true, required: false
+       			input "co2s", "capability.carbonDioxideMeasurement", title: "Carbon Dioxide Detectors", multiple: true, required: false
+        		input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
+	        	input "consumables", "capability.consumable", title: "Consumables", multiple: true, required: false
+    	    	input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
+        		input "doorsControllers", "capability.doorControl", title: "Door Controllers", multiple: true, required: false
+        		input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
+        		input "humidities", "capability.relativeHumidityMeasurement", title: "Humidity Meters", multiple: true, required: false
+	        	input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
+    	    	input "locks", "capability.lock", title: "Locks", multiple: true, required: false
+        		input "motions", "capability.motionSensor", title: "Motion Sensors", multiple: true, required: false
+        		input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
+	        	input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
+    	    	input "phMeters", "capability.pHMeasurement", title: "pH Meters", multiple: true, required: false
+        		input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
+        		input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
+	        	input "pressures", "capability.sensor", title: "Pressure Sensors", multiple: true, required: false
+    	    	input "shockSensors", "capability.shockSensor", title: "Shock Sensors", multiple: true, required: false
+        		input "signalStrengthMeters", "capability.signalStrength", title: "Signal Strength Meters", multiple: true, required: false
+        		input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
+	        	input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
+    	    	input "soundSensors", "capability.soundSensor", title: "Sound Sensors", multiple: true, required: false
+				input "spls", "capability.soundPressureLevel", title: "Sound Pressure Level Sensors", multiple: true, required: false
+				input "switches", "capability.switch", title: "Switches", multiple: true, required: false
+	        	input "switchLevels", "capability.switchLevel", title: "Switch Levels", multiple: true, required: false
+    	    	input "tamperAlerts", "capability.tamperAlert", title: "Tamper Alerts", multiple: true, required: false
+        		input "temperatures", "capability.temperatureMeasurement", title: "Temperature Sensors", multiple: true, required: false
+        		input "thermostats", "capability.thermostat", title: "Thermostats", multiple: true, required: false
+	        	input "threeAxis", "capability.threeAxis", title: "Three-axis (Orientation) Sensors", multiple: true, required: false
+    	    	input "touchs", "capability.touchSensor", title: "Touch Sensors", multiple: true, required: false
+        		input "uvs", "capability.ultravioletIndex", title: "UV Sensors", multiple: true, required: false
+        		input "valves", "capability.valve", title: "Valves", multiple: true, required: false
+	        	input "volts", "capability.voltageMeasurement", title: "Voltage Meters", multiple: true, required: false
+    	    	input "waterSensors", "capability.waterSensor", title: "Water Sensors", multiple: true, required: false
+        		input "windowShades", "capability.windowShade", title: "Window Shades", multiple: true, required: false
+    		}
+		} else {
+			section("Devices To Monitor:", hideable:false,hidden:false) {
+				input name: "allDevices", type: "capability.*", title: "Selected Devices", multiple: true, required: false, submitOnChange: true
+			}
+			state.selectedAttr=[:]
+			settings.allDevices.each { deviceName ->
+				if(deviceName) {
+					deviceId = deviceName.getId()
+       				attr = deviceName.getSupportedAttributes().unique()
+					if(attr) {
+						state.options =[]
+						index = 0
+						attr.each {at->
+							state.options[index] = "${at}"
+							index = index+1
+						}
+                        section("$deviceName", hideable: true) {
+								input name:"attrForDev$deviceId", type: "enum", title: "$deviceName", options: state.options, multiple: true, required: false, submitOnChange: true
+						}
+						state.selectedAttr[deviceId] = settings["attrForDev"+deviceId]
+					}
+				}
+           	}
+		}		
+	}
+}
+
+def connectionPage() {
+	dynamicPage(name: "connectionPage", title: "Connection Properties", install: false, uninstall: false) {
+        section {
+        
+            input "prefDatabaseHost", "text", title: "Host", defaultValue: "192.168.1.100", required: true
+            input "prefDatabaseTls", "bool", title:"Use TLS?", defaultValue: false, required: true
+
+            input "prefDatabasePort", "text", title: "Port", defaultValue: prefDatabaseTls?"443":"8086", required: false
+            input (
+                name: "prefInfluxVer",
+                title: "Influx Version",
                 type: "enum",
                 options: [
-                    "0" : "None",
-                    "1" : "Error",
-                    "2" : "Warning",
-                    "3" : "Info",
-                    "4" : "Debug",
-                    "5" : "Trace"
+                    "1" : "v1.x",
+                    "2" : "v2.x"
                 ],
-                defaultValue: "3",
-                displayDuringSetup: true,
-                required: false
+                defaultValue: "1",
+                submitOnChange: true,
+                required: true
             )
-        }
-
-        section("InfluxDB Database:") {
-            input "prefDatabaseHost", "text", title: "Host", defaultValue: "192.168.1.100", required: true
-            input "prefDatabasePort", "text", title: "Port", defaultValue: "8086", required: true
-            input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
-            input "prefDatabaseUser", "text", title: "Username", required: false
-            input "prefDatabasePass", "text", title: "Password", required: false
-        }
-
-        section("Polling / Write frequency:") {
-            input "prefSoftPollingInterval", "number", title:"Soft-Polling interval (minutes)", defaultValue: 10, required: true
-
-            input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
-                options: ["1",  "2", "3", "4", "5", "10", "15"]
-        }
-
-        section("System Monitoring:") {
-            input "prefLogModeEvents", "bool", title:"Log Mode Events?", defaultValue: true, required: true
-            input "prefLogHubProperties", "bool", title:"Log Hub Properties?", defaultValue: true, required: true
-            input "prefLogLocationProperties", "bool", title:"Log Location Properties?", defaultValue: true, required: true
-        }
-
-        section("Input Format Preference:") {
-            input "accessAllAttributes", "bool", title:"Get Access To All Attributes?", defaultValue: false, required: true, submitOnChange: true
-        }
-
-        if (!accessAllAttributes) {
-            section("Devices To Monitor:", hideable:false, hidden:false) {
-                input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
-                input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
-                input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
-                input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
-                input "buttons", "capability.button", title: "Buttons", multiple: true, required: false
-                input "cos", "capability.carbonMonoxideDetector", title: "Carbon Monoxide Detectors", multiple: true, required: false
-                input "co2s", "capability.carbonDioxideMeasurement", title: "Carbon Dioxide Detectors", multiple: true, required: false
-                input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
-                input "consumables", "capability.consumable", title: "Consumables", multiple: true, required: false
-                input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
-                input "doorsControllers", "capability.doorControl", title: "Door Controllers", multiple: true, required: false
-                input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
-                input "humidities", "capability.relativeHumidityMeasurement", title: "Humidity Meters", multiple: true, required: false
-                input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
-                input "locks", "capability.lock", title: "Locks", multiple: true, required: false
-                input "motions", "capability.motionSensor", title: "Motion Sensors", multiple: true, required: false
-                input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
-                input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
-                input "phMeters", "capability.pHMeasurement", title: "pH Meters", multiple: true, required: false
-                input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
-                input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
-                input "pressures", "capability.sensor", title: "Pressure Sensors", multiple: true, required: false
-                input "shockSensors", "capability.shockSensor", title: "Shock Sensors", multiple: true, required: false
-                input "signalStrengthMeters", "capability.signalStrength", title: "Signal Strength Meters", multiple: true, required: false
-                input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
-                input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
-                input "soundSensors", "capability.soundSensor", title: "Sound Sensors", multiple: true, required: false
-                input "spls", "capability.soundPressureLevel", title: "Sound Pressure Level Sensors", multiple: true, required: false
-                input "switches", "capability.switch", title: "Switches", multiple: true, required: false
-                input "switchLevels", "capability.switchLevel", title: "Switch Levels", multiple: true, required: false
-                input "tamperAlerts", "capability.tamperAlert", title: "Tamper Alerts", multiple: true, required: false
-                input "temperatures", "capability.temperatureMeasurement", title: "Temperature Sensors", multiple: true, required: false
-                input "thermostats", "capability.thermostat", title: "Thermostats", multiple: true, required: false
-                input "threeAxis", "capability.threeAxis", title: "Three-axis (Orientation) Sensors", multiple: true, required: false
-                input "touchs", "capability.touchSensor", title: "Touch Sensors", multiple: true, required: false
-                input "uvs", "capability.ultravioletIndex", title: "UV Sensors", multiple: true, required: false
-                input "valves", "capability.valve", title: "Valves", multiple: true, required: false
-                input "volts", "capability.voltageMeasurement", title: "Voltage Meters", multiple: true, required: false
-                input "waterSensors", "capability.waterSensor", title: "Water Sensors", multiple: true, required: false
-                input "windowShades", "capability.windowShade", title: "Window Shades", multiple: true, required: false
-            }
-        } else {
-            section("Devices To Monitor:", hideable:false, hidden:false) {
-                input name: "allDevices", type: "capability.*", title: "Selected Devices", multiple: true, required: false, submitOnChange: true
-            }
-
-            state.selectedAttr = [:]
-            settings.allDevices.each { deviceName ->
-                if (deviceName) {
-                    deviceId = deviceName.getId()
-                    attr = deviceName.getSupportedAttributes().unique()
-                    if (attr) {
-                        state.options = []
-                        index = 0
-                        attr.each { at->
-                            state.options[index] = "${at}"
-                            index = index + 1
-                        }
-
-                        section("$deviceName", hideable: true) {
-                                input name:"attrForDev$deviceId", type: "enum", title: "$deviceName", options: state.options, multiple: true, required: false, submitOnChange: true
-                        }
-
-                        state.selectedAttr[deviceId] = settings["attrForDev" + deviceId]
-                    }
-                }
+            if (prefInfluxVer == "1") {
+                input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
+            } else if (prefInfluxVer == "2") {
+                input "prefOrg", "text", title: "Org", defaultValue: "", required: true
+                input "prefBucket", "text", title: "Bucket", defaultValue: "", required: true
+            }          
+            
+            input (
+                name: "prefAuthType",
+                title: "Authorization Type",
+                type: "enum",
+                options: [
+                    "none" : "None",
+                    "basic" : "Username / Password",
+                    "token" : "Token"
+                ],
+                defaultValue: "none",
+                submitOnChange: true,
+                required: true
+            )
+            
+            if (prefAuthType == "basic") {
+                input "prefDatabaseUser", "text", title: "Username", defaultValue: "", required: false
+                input "prefDatabasePass", "text", title: "Password", defaultValue: "", required: false
+            } else if (prefAuthType == "token") {
+                input "prefDatabaseToken", "text", title: "Token", required: true
             }
         }
     }
 }
-
 
 def getDeviceObj(id) {
     def found
@@ -229,19 +287,45 @@ def updated() {
     // Update internal state:
     state.loggingLevelIDE = (settings.configLoggingLevelIDE) ? settings.configLoggingLevelIDE.toInteger() : 3
 
-    // Database config:
+// Database config:
     state.databaseHost = settings.prefDatabaseHost
+    state.databaseTls = settings.prefDatabaseTls
     state.databasePort = settings.prefDatabasePort
+
+    state.influxVer = settings.prefInfluxVer   
     state.databaseName = settings.prefDatabaseName
+    state.org = settings.prefOrg
+    state.bucket = settings.prefBucket
+    
+    state.authType = settings.prefAuthType
     state.databaseUser = settings.prefDatabaseUser
     state.databasePass = settings.prefDatabasePass
+    state.databaseToken = settings.prefDatabaseToken
 
-    state.path = "/write?db=${state.databaseName}"
-    state.headers = [:]
-    //state.headers.put("HOST", "${state.databaseHost}:${state.databasePort}")
-    //state.headers.put("Content-Type", "application/x-www-form-urlencoded")
-    if (state.databaseUser && state.databasePass) {
+    state.uri = "";
+    if (state.databaseTls) {
+        state.uri += "https://";
+    } else {
+        state.uri += "http://";
+    }
+    state.uri += state.databaseHost;
+    
+    if (state.databasePort != null) {
+        state.uri += ":"+state.databasePort;
+    }
+    
+    if (state?.influxVer == "1" || state?.influxVer == null) {
+        state.uri += "/write?db=${state.databaseName}"
+    } else if (state?.influxVer == "2") {
+        state.uri += "/api/v2/write?org=${state.org}&bucket=${state.bucket}"
+    }
+
+    state.headers = [:] 
+  
+    if (state.authType == "basic") {
         state.headers.put("Authorization", encodeCredentialsBasic(state.databaseUser, state.databasePass))
+    } else if (state.authType == "token") {
+        state.headers.put("Authorization", "Token ${state.databaseToken}")
     }
 
     // Build array of device collections and the attributes we want to report on for that collection:
@@ -755,7 +839,7 @@ def postToInfluxDB(data) {
 
     try {
         def postParams = [
-            uri: "http://${state.databaseHost}:${state.databasePort}/write?db=${state.databaseName}" ,
+            uri: state.uri,
             requestContentType: 'application/json',
             contentType: 'application/json',
             headers: state.headers,

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -273,36 +273,27 @@ def updated() {
     state.loggingLevelIDE = (settings.configLoggingLevelIDE) ? settings.configLoggingLevelIDE.toInteger() : 3
 
 // Database config:
-    state.databaseHost = settings.prefDatabaseHost
-    state.databaseTls = settings.prefDatabaseTls
-    state.databasePort = settings.prefDatabasePort
-
-    state.influxVer = settings.prefInfluxVer   
-    state.databaseName = settings.prefDatabaseName
-    state.org = settings.prefOrg
-    state.bucket = settings.prefBucket
-    
     state.authType = settings.prefAuthType
     state.databaseUser = settings.prefDatabaseUser
     state.databasePass = settings.prefDatabasePass
     state.databaseToken = settings.prefDatabaseToken
 
     state.uri = "";
-    if (state.databaseTls) {
+    if (settings.prefDatabaseTls) {
         state.uri += "https://";
     } else {
         state.uri += "http://";
     }
-    state.uri += state.databaseHost;
+    state.uri += settings.prefDatabaseHost;
     
-    if (state.databasePort != null) {
-        state.uri += ":"+state.databasePort;
+    if (settings.prefDatabasePort != null) {
+        state.uri += ":"+settings.prefDatabasePort;
     }
     
-    if (state?.influxVer == "1" || state?.influxVer == null) {
-        state.uri += "/write?db=${state.databaseName}"
-    } else if (state?.influxVer == "2") {
-        state.uri += "/api/v2/write?org=${state.org}&bucket=${state.bucket}"
+    if (settings?.prefInfluxVer == "1" || settings?.prefInfluxVer == null) {
+        state.uri += "/write?db=${settings.prefDatabaseName}"
+    } else if (settings?.prefInfluxVer == "2") {
+        state.uri += "/api/v2/write?org=${settings.prefOrg}&bucket=${settings.prefBucket}"
     }
 
     state.headers = [:] 
@@ -818,7 +809,7 @@ def writeQueuedDataToInfluxDb() {
  *  Uses hubAction instead of httpPost() in case InfluxDB server is on the same LAN as the Smartthings Hub.
  **/
 def postToInfluxDB(data) {
-    logger("postToInfluxDB(): Posting data to InfluxDB: Host: ${state.databaseHost}, Port: ${state.databasePort}, Database: ${state.databaseName}, Data: [${data}]", "info")
+    logger("postToInfluxDB(): Posting data to InfluxDB: ${state.uri}, Data: [${data}]","info") 
 
     // Hubitat Async http Post
 

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -47,102 +47,100 @@ definition(
     @Field static java.util.concurrent.Semaphore mutex = new java.util.concurrent.Semaphore(1)
 
 preferences {
-      	page(name: "setupMain")
-        page(name: "connectionPage")
+	page(name: "setupMain")
+	page(name: "connectionPage")
 }
 
 def setupMain() {
     dynamicPage(name: "setupMain", title: "New Settings Page", install: true, uninstall: true) {
-	    section("General:") {
-    	    //input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true
+		section("General:") {
+			//input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true            
+			href(
+			name: "href",
+			title: "Connection Settings",
+			description: prefDatabaseHost==null?"Configure database connection parameters":prefDatabaseHost,
+			required: true,
+			page: "connectionPage"
+			)
             
-            href(
-                name: "href",
-                title: "Connection Settings",
-                description: prefDatabaseHost==null?"Configure database connection parameters":prefDatabaseHost,
-                required: true,
-                page: "connectionPage"
-            )
-            
-        	input (
-        		name: "configLoggingLevelIDE",
-        		title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
-        		type: "enum",
-        		options: [
-	        	    "0" : "None",
-    	    	    "1" : "Error",
-        		    "2" : "Warning",
-        		    "3" : "Info",
-        	    	"4" : "Debug",
-	        	    "5" : "Trace"
-    	    	],
-        		defaultValue: "3",
-            	displayDuringSetup: true,
-	        	required: false
-    	    )
-    	}
+			input (
+				name: "configLoggingLevelIDE",
+				title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
+				type: "enum",
+				options: [
+					"0" : "None",
+					"1" : "Error",
+					"2" : "Warning",
+ 					"3" : "Info",
+					"4" : "Debug",
+					"5" : "Trace"
+				],
+				defaultValue: "3",
+				displayDuringSetup: true,
+				required: false
+			)
+		}
 
-  	    section("Polling / Write frequency:") {
-	        input "prefSoftPollingInterval", "number", title:"Soft-Polling interval (minutes)", defaultValue: 10, required: true
+		section("Polling / Write frequency:") {
+			input "prefSoftPollingInterval", "number", title:"Soft-Polling interval (minutes)", defaultValue: 10, required: true
 
-    	    input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
-        		options: ["1",  "2", "3", "4", "5", "10", "15"]
-    	}
+			input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
+				options: ["1",  "2", "3", "4", "5", "10", "15"]
+		}
 
-	    section("System Monitoring:") {
-    	    input "prefLogModeEvents", "bool", title:"Log Mode Events?", defaultValue: true, required: true
-        	input "prefLogHubProperties", "bool", title:"Log Hub Properties?", defaultValue: true, required: true
-        	input "prefLogLocationProperties", "bool", title:"Log Location Properties?", defaultValue: true, required: true
-    	}
+		section("System Monitoring:") {
+			input "prefLogModeEvents", "bool", title:"Log Mode Events?", defaultValue: true, required: true
+			input "prefLogHubProperties", "bool", title:"Log Hub Properties?", defaultValue: true, required: true
+			input "prefLogLocationProperties", "bool", title:"Log Location Properties?", defaultValue: true, required: true
+		}
 
 		section("Input Format Preference:") {
 			input "accessAllAttributes", "bool", title:"Get Access To All Attributes?", defaultValue: false, required: true, submitOnChange: true
 		}
 
-		if(!accessAllAttributes)
-		{
-	       	section("Devices To Monitor:", hideable:false,hidden:false) {
-    	 	  	input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
-       			input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
-       			input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
-       			input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
-	       		input "buttons", "capability.button", title: "Buttons", multiple: true, required: false
-    	  		input "cos", "capability.carbonMonoxideDetector", title: "Carbon Monoxide Detectors", multiple: true, required: false
-       			input "co2s", "capability.carbonDioxideMeasurement", title: "Carbon Dioxide Detectors", multiple: true, required: false
-        		input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
-	        	input "consumables", "capability.consumable", title: "Consumables", multiple: true, required: false
-    	    	input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
-        		input "doorsControllers", "capability.doorControl", title: "Door Controllers", multiple: true, required: false
-        		input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
-        		input "humidities", "capability.relativeHumidityMeasurement", title: "Humidity Meters", multiple: true, required: false
-	        	input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
-    	    	input "locks", "capability.lock", title: "Locks", multiple: true, required: false
-        		input "motions", "capability.motionSensor", title: "Motion Sensors", multiple: true, required: false
-        		input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
-	        	input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
-    	    	input "phMeters", "capability.pHMeasurement", title: "pH Meters", multiple: true, required: false
-        		input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
-        		input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
-	        	input "pressures", "capability.sensor", title: "Pressure Sensors", multiple: true, required: false
-    	    	input "shockSensors", "capability.shockSensor", title: "Shock Sensors", multiple: true, required: false
-        		input "signalStrengthMeters", "capability.signalStrength", title: "Signal Strength Meters", multiple: true, required: false
-        		input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
-	        	input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
-    	    	input "soundSensors", "capability.soundSensor", title: "Sound Sensors", multiple: true, required: false
+		if(!accessAllAttributes) {
+			section("Devices To Monitor:", hideable:false,hidden:false) {
+				input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
+				input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
+				input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
+				input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
+				input "buttons", "capability.button", title: "Buttons", multiple: true, required: false
+				input "cos", "capability.carbonMonoxideDetector", title: "Carbon Monoxide Detectors", multiple: true, required: false
+				input "co2s", "capability.carbonDioxideMeasurement", title: "Carbon Dioxide Detectors", multiple: true, required: false
+				input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
+				input "consumables", "capability.consumable", title: "Consumables", multiple: true, required: false
+				input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
+				input "doorsControllers", "capability.doorControl", title: "Door Controllers", multiple: true, required: false
+				input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
+				input "humidities", "capability.relativeHumidityMeasurement", title: "Humidity Meters", multiple: true, required: false
+				input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
+				input "locks", "capability.lock", title: "Locks", multiple: true, required: false
+				input "motions", "capability.motionSensor", title: "Motion Sensors", multiple: true, required: false
+				input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
+				input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
+				input "phMeters", "capability.pHMeasurement", title: "pH Meters", multiple: true, required: false
+				input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
+				input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
+				input "pressures", "capability.sensor", title: "Pressure Sensors", multiple: true, required: false
+				input "shockSensors", "capability.shockSensor", title: "Shock Sensors", multiple: true, required: false
+				input "signalStrengthMeters", "capability.signalStrength", title: "Signal Strength Meters", multiple: true, required: false
+				input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
+				input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
+				input "soundSensors", "capability.soundSensor", title: "Sound Sensors", multiple: true, required: false
 				input "spls", "capability.soundPressureLevel", title: "Sound Pressure Level Sensors", multiple: true, required: false
 				input "switches", "capability.switch", title: "Switches", multiple: true, required: false
-	        	input "switchLevels", "capability.switchLevel", title: "Switch Levels", multiple: true, required: false
-    	    	input "tamperAlerts", "capability.tamperAlert", title: "Tamper Alerts", multiple: true, required: false
-        		input "temperatures", "capability.temperatureMeasurement", title: "Temperature Sensors", multiple: true, required: false
-        		input "thermostats", "capability.thermostat", title: "Thermostats", multiple: true, required: false
-	        	input "threeAxis", "capability.threeAxis", title: "Three-axis (Orientation) Sensors", multiple: true, required: false
-    	    	input "touchs", "capability.touchSensor", title: "Touch Sensors", multiple: true, required: false
-        		input "uvs", "capability.ultravioletIndex", title: "UV Sensors", multiple: true, required: false
-        		input "valves", "capability.valve", title: "Valves", multiple: true, required: false
-	        	input "volts", "capability.voltageMeasurement", title: "Voltage Meters", multiple: true, required: false
-    	    	input "waterSensors", "capability.waterSensor", title: "Water Sensors", multiple: true, required: false
-        		input "windowShades", "capability.windowShade", title: "Window Shades", multiple: true, required: false
-    		}
+				input "switchLevels", "capability.switchLevel", title: "Switch Levels", multiple: true, required: false
+				input "tamperAlerts", "capability.tamperAlert", title: "Tamper Alerts", multiple: true, required: false
+				input "temperatures", "capability.temperatureMeasurement", title: "Temperature Sensors", multiple: true, required: false
+				input "thermostats", "capability.thermostat", title: "Thermostats", multiple: true, required: false
+				input "threeAxis", "capability.threeAxis", title: "Three-axis (Orientation) Sensors", multiple: true, required: false
+				input "touchs", "capability.touchSensor", title: "Touch Sensors", multiple: true, required: false
+				input "uvs", "capability.ultravioletIndex", title: "UV Sensors", multiple: true, required: false
+				input "valves", "capability.valve", title: "Valves", multiple: true, required: false
+				input "volts", "capability.voltageMeasurement", title: "Voltage Meters", multiple: true, required: false
+				input "waterSensors", "capability.waterSensor", title: "Water Sensors", multiple: true, required: false
+				input "windowShades", "capability.windowShade", title: "Window Shades", multiple: true, required: false
+			}
 		} else {
 			section("Devices To Monitor:", hideable:false,hidden:false) {
 				input name: "allDevices", type: "capability.*", title: "Selected Devices", multiple: true, required: false, submitOnChange: true
@@ -151,7 +149,7 @@ def setupMain() {
 			settings.allDevices.each { deviceName ->
 				if(deviceName) {
 					deviceId = deviceName.getId()
-       				attr = deviceName.getSupportedAttributes().unique()
+					attr = deviceName.getSupportedAttributes().unique()
 					if(attr) {
 						state.options =[]
 						index = 0
@@ -159,77 +157,73 @@ def setupMain() {
 							state.options[index] = "${at}"
 							index = index+1
 						}
-                        section("$deviceName", hideable: true) {
-								input name:"attrForDev$deviceId", type: "enum", title: "$deviceName", options: state.options, multiple: true, required: false, submitOnChange: true
+						section("$deviceName", hideable: true) {
+							input name:"attrForDev$deviceId", type: "enum", title: "$deviceName", options: state.options, multiple: true, required: false, submitOnChange: true
 						}
 						state.selectedAttr[deviceId] = settings["attrForDev"+deviceId]
 					}
 				}
-           	}
+			}
 		}		
 	}
 }
 
 def connectionPage() {
 	dynamicPage(name: "connectionPage", title: "Connection Properties", install: false, uninstall: false) {
-        section {
-        
-            input "prefDatabaseHost", "text", title: "Host", defaultValue: "192.168.1.100", required: true
-            input "prefDatabaseTls", "bool", title:"Use TLS?", defaultValue: false, required: true
-
-            input "prefDatabasePort", "text", title: "Port", defaultValue: prefDatabaseTls?"443":"8086", required: false
-            input (
-                name: "prefInfluxVer",
-                title: "Influx Version",
-                type: "enum",
-                options: [
-                    "1" : "v1.x",
-                    "2" : "v2.x"
-                ],
-                defaultValue: "1",
-                submitOnChange: true,
-                required: true
-            )
-            if (prefInfluxVer == "1") {
-                input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
-            } else if (prefInfluxVer == "2") {
-                input "prefOrg", "text", title: "Org", defaultValue: "", required: true
-                input "prefBucket", "text", title: "Bucket", defaultValue: "", required: true
-            }          
+		section {        
+			input "prefDatabaseHost", "text", title: "Host", defaultValue: "192.168.1.100", required: true
+			input "prefDatabaseTls", "bool", title:"Use TLS?", defaultValue: false, required: true
+			input "prefDatabasePort", "text", title: "Port", defaultValue: prefDatabaseTls?"443":"8086", required: false
+			input (
+				name: "prefInfluxVer",
+				title: "Influx Version",
+				type: "enum",
+				options: [
+					"1" : "v1.x",
+					"2" : "v2.x"
+			],
+			defaultValue: "1",
+			submitOnChange: true,
+			required: true
+		)
+		if (prefInfluxVer == "1") {
+			input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
+		} else if (prefInfluxVer == "2") {
+			input "prefBucket", "text", title: "Bucket", defaultValue: "", required: true
+		}          
             
-            input (
-                name: "prefAuthType",
-                title: "Authorization Type",
-                type: "enum",
-                options: [
-					"none" : "None",
-                    "basic" : "Username / Password",
-                    "token" : "Token"
-                ],
-                defaultValue: "basic",
-                submitOnChange: true,
-                required: true
-            )
-            
-            if (prefAuthType == "basic") {
-                input "prefDatabaseUser", "text", title: "Username", defaultValue: "", required: false
-                input "prefDatabasePass", "text", title: "Password", defaultValue: "", required: false
-            } else if (prefAuthType == "token") {
-                input "prefDatabaseToken", "text", title: "Token", required: true
-            }
-        }
-    }
+		input (
+			name: "prefAuthType",
+			title: "Authorization Type",
+			type: "enum",
+			options: [
+				"none" : "None",
+				"basic" : "Username / Password",
+				"token" : "Token"
+			],
+			defaultValue: "basic",
+			submitOnChange: true,
+			required: true
+		)            
+		if (prefAuthType == "basic") {
+			input "prefDatabaseUser", "text", title: "Username", defaultValue: "", required: false
+			input "prefDatabasePass", "text", title: "Password", defaultValue: "", required: false
+		} else if (prefAuthType == "token") {
+			input "prefDatabaseToken", "text", title: "Token", required: true
+			}
+		}
+	}
 }
 
 def getDeviceObj(id) {
-    def found
-    settings.allDevices.each { device ->
-        if (device.getId() == id) {
+	def found
+	settings.allDevices.each { device ->
+	if (device.getId() == id) {
             //log.debug "Found at $device for $id with id: ${device.id}"
-            found = device
-        }
-    }
-    return found
+		found = device
+		}
+	}
+	return found
 }
 
 

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -29,7 +29,7 @@
  *   2019-09-09 Caleb Morse     Support deferring writes and doing buld writes to influxdb
  *   2022-06-20 Denny Page      Remove nested sections for device selection
  *   2023-01-08 Denny Page      Address whitespace related lint issues. No functional changes.
- *   2023-01-09 Craig		Added InfluxDb2.x support
+ *   2023-01-09 Craig        Added InfluxDb2.x support
  *****************************************************************************************************************/
 definition(
     name: "InfluxDB Logger",
@@ -54,7 +54,7 @@ preferences {
 def setupMain() {
     dynamicPage(name: "setupMain", title: "New Settings Page", install: true, uninstall: true) {
         section("General:") {
-            //input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true            
+            //input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true
             href(
             name: "href",
             title: "Connection Settings",
@@ -62,7 +62,7 @@ def setupMain() {
             required: true,
             page: "connectionPage"
             )
-            
+
             input (
                 name: "configLoggingLevelIDE",
                 title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
@@ -225,8 +225,6 @@ def getDeviceObj(id) {
     return found
 }
 
-
-
 /*****************************************************************************************************************
  *  SmartThings System Commands:
  *****************************************************************************************************************/
@@ -285,19 +283,19 @@ def updated() {
         state.uri += "http://";
     }
     state.uri += settings.prefDatabaseHost;
-    
+
     if (settings.prefDatabasePort != null) {
         state.uri += ":"+settings.prefDatabasePort;
     }
-    
+
     if (settings?.prefInfluxVer == "1" || settings?.prefInfluxVer == null) {
         state.uri += "/write?db=${settings.prefDatabaseName}"
     } else if (settings?.prefInfluxVer == "2") {
         state.uri += "/api/v2/write?org=${settings.prefOrg}&bucket=${settings.prefBucket}"
     }
 
-    state.headers = [:] 
-  
+    state.headers = [:]
+
     if (state.authType == "basic") {
         state.headers.put("Authorization", encodeCredentialsBasic(state.databaseUser, state.databasePass))
     } else if (state.authType == "token") {
@@ -615,7 +613,6 @@ def handleEvent(evt) {
     queueToInfluxDb(data)
 }
 
-
 /*****************************************************************************************************************
  *  Main Commands:
  *****************************************************************************************************************/
@@ -809,7 +806,7 @@ def writeQueuedDataToInfluxDb() {
  *  Uses hubAction instead of httpPost() in case InfluxDB server is on the same LAN as the Smartthings Hub.
  **/
 def postToInfluxDB(data) {
-    logger("postToInfluxDB(): Posting data to InfluxDB: ${state.uri}, Data: [${data}]","info") 
+    logger("postToInfluxDB(): Posting data to InfluxDB: ${state.uri}, Data: [${data}]","info")
 
     // Hubitat Async http Post
 
@@ -838,7 +835,6 @@ def handleInfluxResponse(hubResponse, data) {
         logger("postToInfluxDB(): Something went wrong! Response from InfluxDB: Status: ${hubResponse.status}, Headers: ${hubResponse.headers}, Data: ${data}", "error")
     }
 }
-
 
 /*****************************************************************************************************************
  *  Private Helper Functions:

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -50,7 +50,6 @@ preferences {
         page(name: "connectionPage")
 }
 
-
 def setupMain() {
     dynamicPage(name: "setupMain", title: "New Settings Page", install: true, uninstall: true) {
 	    section("General:") {

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -47,183 +47,182 @@ definition(
     @Field static java.util.concurrent.Semaphore mutex = new java.util.concurrent.Semaphore(1)
 
 preferences {
-	page(name: "setupMain")
-	page(name: "connectionPage")
+    page(name: "setupMain")
+    page(name: "connectionPage")
 }
 
 def setupMain() {
     dynamicPage(name: "setupMain", title: "New Settings Page", install: true, uninstall: true) {
-		section("General:") {
-			//input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true            
-			href(
-			name: "href",
-			title: "Connection Settings",
-			description: prefDatabaseHost==null?"Configure database connection parameters":prefDatabaseHost,
-			required: true,
-			page: "connectionPage"
-			)
+        section("General:") {
+            //input "prefDebugMode", "bool", title: "Enable debug logging?", defaultValue: true, displayDuringSetup: true            
+            href(
+            name: "href",
+            title: "Connection Settings",
+            description: prefDatabaseHost==null?"Configure database connection parameters":prefDatabaseHost,
+            required: true,
+            page: "connectionPage"
+            )
             
-			input (
-				name: "configLoggingLevelIDE",
-				title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
-				type: "enum",
-				options: [
-					"0" : "None",
-					"1" : "Error",
-					"2" : "Warning",
- 					"3" : "Info",
-					"4" : "Debug",
-					"5" : "Trace"
-				],
-				defaultValue: "3",
-				displayDuringSetup: true,
-				required: false
-			)
-		}
+            input (
+                name: "configLoggingLevelIDE",
+                title: "IDE Live Logging Level:\nMessages with this level and higher will be logged to the IDE.",
+                type: "enum",
+                options: [
+                    "0" : "None",
+                    "1" : "Error",
+                    "2" : "Warning",
+                    "3" : "Info",
+                    "4" : "Debug",
+                    "5" : "Trace"
+                ],
+                defaultValue: "3",
+                displayDuringSetup: true,
+                required: false
+            )
+        }
 
-		section("Polling / Write frequency:") {
-			input "prefSoftPollingInterval", "number", title:"Soft-Polling interval (minutes)", defaultValue: 10, required: true
+        section("Polling / Write frequency:") {
+            input "prefSoftPollingInterval", "number", title:"Soft-Polling interval (minutes)", defaultValue: 10, required: true
 
-			input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
-				options: ["1",  "2", "3", "4", "5", "10", "15"]
-		}
+            input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
+                options: ["1",  "2", "3", "4", "5", "10", "15"]
+        }
 
-		section("System Monitoring:") {
-			input "prefLogModeEvents", "bool", title:"Log Mode Events?", defaultValue: true, required: true
-			input "prefLogHubProperties", "bool", title:"Log Hub Properties?", defaultValue: true, required: true
-			input "prefLogLocationProperties", "bool", title:"Log Location Properties?", defaultValue: true, required: true
-		}
+        section("System Monitoring:") {
+            input "prefLogModeEvents", "bool", title:"Log Mode Events?", defaultValue: true, required: true
+            input "prefLogHubProperties", "bool", title:"Log Hub Properties?", defaultValue: true, required: true
+            input "prefLogLocationProperties", "bool", title:"Log Location Properties?", defaultValue: true, required: true
+        }
 
-		section("Input Format Preference:") {
-			input "accessAllAttributes", "bool", title:"Get Access To All Attributes?", defaultValue: false, required: true, submitOnChange: true
-		}
+        section("Input Format Preference:") {
+            input "accessAllAttributes", "bool", title:"Get Access To All Attributes?", defaultValue: false, required: true, submitOnChange: true
+        }
 
-		if(!accessAllAttributes) {
-			section("Devices To Monitor:", hideable:false,hidden:false) {
-				input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
-				input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
-				input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
-				input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
-				input "buttons", "capability.button", title: "Buttons", multiple: true, required: false
-				input "cos", "capability.carbonMonoxideDetector", title: "Carbon Monoxide Detectors", multiple: true, required: false
-				input "co2s", "capability.carbonDioxideMeasurement", title: "Carbon Dioxide Detectors", multiple: true, required: false
-				input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
-				input "consumables", "capability.consumable", title: "Consumables", multiple: true, required: false
-				input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
-				input "doorsControllers", "capability.doorControl", title: "Door Controllers", multiple: true, required: false
-				input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
-				input "humidities", "capability.relativeHumidityMeasurement", title: "Humidity Meters", multiple: true, required: false
-				input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
-				input "locks", "capability.lock", title: "Locks", multiple: true, required: false
-				input "motions", "capability.motionSensor", title: "Motion Sensors", multiple: true, required: false
-				input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
-				input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
-				input "phMeters", "capability.pHMeasurement", title: "pH Meters", multiple: true, required: false
-				input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
-				input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
-				input "pressures", "capability.sensor", title: "Pressure Sensors", multiple: true, required: false
-				input "shockSensors", "capability.shockSensor", title: "Shock Sensors", multiple: true, required: false
-				input "signalStrengthMeters", "capability.signalStrength", title: "Signal Strength Meters", multiple: true, required: false
-				input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
-				input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
-				input "soundSensors", "capability.soundSensor", title: "Sound Sensors", multiple: true, required: false
-				input "spls", "capability.soundPressureLevel", title: "Sound Pressure Level Sensors", multiple: true, required: false
-				input "switches", "capability.switch", title: "Switches", multiple: true, required: false
-				input "switchLevels", "capability.switchLevel", title: "Switch Levels", multiple: true, required: false
-				input "tamperAlerts", "capability.tamperAlert", title: "Tamper Alerts", multiple: true, required: false
-				input "temperatures", "capability.temperatureMeasurement", title: "Temperature Sensors", multiple: true, required: false
-				input "thermostats", "capability.thermostat", title: "Thermostats", multiple: true, required: false
-				input "threeAxis", "capability.threeAxis", title: "Three-axis (Orientation) Sensors", multiple: true, required: false
-				input "touchs", "capability.touchSensor", title: "Touch Sensors", multiple: true, required: false
-				input "uvs", "capability.ultravioletIndex", title: "UV Sensors", multiple: true, required: false
-				input "valves", "capability.valve", title: "Valves", multiple: true, required: false
-				input "volts", "capability.voltageMeasurement", title: "Voltage Meters", multiple: true, required: false
-				input "waterSensors", "capability.waterSensor", title: "Water Sensors", multiple: true, required: false
-				input "windowShades", "capability.windowShade", title: "Window Shades", multiple: true, required: false
-			}
-		} else {
-			section("Devices To Monitor:", hideable:false,hidden:false) {
-				input name: "allDevices", type: "capability.*", title: "Selected Devices", multiple: true, required: false, submitOnChange: true
-			}
-			state.selectedAttr=[:]
-			settings.allDevices.each { deviceName ->
-				if(deviceName) {
-					deviceId = deviceName.getId()
-					attr = deviceName.getSupportedAttributes().unique()
-					if(attr) {
-						state.options =[]
-						index = 0
-						attr.each {at->
-							state.options[index] = "${at}"
-							index = index+1
-						}
-						section("$deviceName", hideable: true) {
-							input name:"attrForDev$deviceId", type: "enum", title: "$deviceName", options: state.options, multiple: true, required: false, submitOnChange: true
-						}
-						state.selectedAttr[deviceId] = settings["attrForDev"+deviceId]
-					}
-				}
-			}
-		}		
-	}
+        if(!accessAllAttributes) {
+            section("Devices To Monitor:", hideable:false,hidden:false) {
+                input "accelerometers", "capability.accelerationSensor", title: "Accelerometers", multiple: true, required: false
+                input "alarms", "capability.alarm", title: "Alarms", multiple: true, required: false
+                input "batteries", "capability.battery", title: "Batteries", multiple: true, required: false
+                input "beacons", "capability.beacon", title: "Beacons", multiple: true, required: false
+                input "buttons", "capability.button", title: "Buttons", multiple: true, required: false
+                input "cos", "capability.carbonMonoxideDetector", title: "Carbon Monoxide Detectors", multiple: true, required: false
+                input "co2s", "capability.carbonDioxideMeasurement", title: "Carbon Dioxide Detectors", multiple: true, required: false
+                input "colors", "capability.colorControl", title: "Color Controllers", multiple: true, required: false
+                input "consumables", "capability.consumable", title: "Consumables", multiple: true, required: false
+                input "contacts", "capability.contactSensor", title: "Contact Sensors", multiple: true, required: false
+                input "doorsControllers", "capability.doorControl", title: "Door Controllers", multiple: true, required: false
+                input "energyMeters", "capability.energyMeter", title: "Energy Meters", multiple: true, required: false
+                input "humidities", "capability.relativeHumidityMeasurement", title: "Humidity Meters", multiple: true, required: false
+                input "illuminances", "capability.illuminanceMeasurement", title: "Illuminance Meters", multiple: true, required: false
+                input "locks", "capability.lock", title: "Locks", multiple: true, required: false
+                input "motions", "capability.motionSensor", title: "Motion Sensors", multiple: true, required: false
+                input "musicPlayers", "capability.musicPlayer", title: "Music Players", multiple: true, required: false
+                input "peds", "capability.stepSensor", title: "Pedometers", multiple: true, required: false
+                input "phMeters", "capability.pHMeasurement", title: "pH Meters", multiple: true, required: false
+                input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
+                input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
+                input "pressures", "capability.sensor", title: "Pressure Sensors", multiple: true, required: false
+                input "shockSensors", "capability.shockSensor", title: "Shock Sensors", multiple: true, required: false
+                input "signalStrengthMeters", "capability.signalStrength", title: "Signal Strength Meters", multiple: true, required: false
+                input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false
+                input "smokeDetectors", "capability.smokeDetector", title: "Smoke Detectors", multiple: true, required: false
+                input "soundSensors", "capability.soundSensor", title: "Sound Sensors", multiple: true, required: false
+                input "spls", "capability.soundPressureLevel", title: "Sound Pressure Level Sensors", multiple: true, required: false
+                input "switches", "capability.switch", title: "Switches", multiple: true, required: false
+                input "switchLevels", "capability.switchLevel", title: "Switch Levels", multiple: true, required: false
+                input "tamperAlerts", "capability.tamperAlert", title: "Tamper Alerts", multiple: true, required: false
+                input "temperatures", "capability.temperatureMeasurement", title: "Temperature Sensors", multiple: true, required: false
+                input "thermostats", "capability.thermostat", title: "Thermostats", multiple: true, required: false
+                input "threeAxis", "capability.threeAxis", title: "Three-axis (Orientation) Sensors", multiple: true, required: false
+                input "touchs", "capability.touchSensor", title: "Touch Sensors", multiple: true, required: false
+                input "uvs", "capability.ultravioletIndex", title: "UV Sensors", multiple: true, required: false
+                input "valves", "capability.valve", title: "Valves", multiple: true, required: false
+                input "volts", "capability.voltageMeasurement", title: "Voltage Meters", multiple: true, required: false
+                input "waterSensors", "capability.waterSensor", title: "Water Sensors", multiple: true, required: false
+                input "windowShades", "capability.windowShade", title: "Window Shades", multiple: true, required: false
+            }
+        } else {
+            section("Devices To Monitor:", hideable:false,hidden:false) {
+                input name: "allDevices", type: "capability.*", title: "Selected Devices", multiple: true, required: false, submitOnChange: true
+            }
+            state.selectedAttr=[:]
+            settings.allDevices.each { deviceName ->
+                if(deviceName) {
+                    deviceId = deviceName.getId()
+                    attr = deviceName.getSupportedAttributes().unique()
+                    if(attr) {
+                        state.options =[]
+                        index = 0
+                        attr.each {at->
+                            state.options[index] = "${at}"
+                            index = index+1
+                        }
+                        section("$deviceName", hideable: true) {
+                            input name:"attrForDev$deviceId", type: "enum", title: "$deviceName", options: state.options, multiple: true, required: false, submitOnChange: true
+                        }
+                        state.selectedAttr[deviceId] = settings["attrForDev"+deviceId]
+                    }
+                }
+            }
+        }
+    }
 }
 
 def connectionPage() {
-	dynamicPage(name: "connectionPage", title: "Connection Properties", install: false, uninstall: false) {
-		section {        
-			input "prefDatabaseHost", "text", title: "Host", defaultValue: "192.168.1.100", required: true
-			input "prefDatabaseTls", "bool", title:"Use TLS?", defaultValue: false, required: true
-			input "prefDatabasePort", "text", title: "Port", defaultValue: prefDatabaseTls?"443":"8086", required: false
-			input (
-				name: "prefInfluxVer",
-				title: "Influx Version",
-				type: "enum",
-				options: [
-					"1" : "v1.x",
-					"2" : "v2.x"
-			],
-			defaultValue: "1",
-			submitOnChange: true,
-			required: true
-		)
-		if (prefInfluxVer == "1") {
-			input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
-		} else if (prefInfluxVer == "2") {
-			input "prefBucket", "text", title: "Bucket", defaultValue: "", required: true
-		}          
-            
-		input (
-			name: "prefAuthType",
-			title: "Authorization Type",
-			type: "enum",
-			options: [
-				"none" : "None",
-				"basic" : "Username / Password",
-				"token" : "Token"
-			],
-			defaultValue: "basic",
-			submitOnChange: true,
-			required: true
-		)            
-		if (prefAuthType == "basic") {
-			input "prefDatabaseUser", "text", title: "Username", defaultValue: "", required: false
-			input "prefDatabasePass", "text", title: "Password", defaultValue: "", required: false
-		} else if (prefAuthType == "token") {
-			input "prefDatabaseToken", "text", title: "Token", required: true
-			}
-		}
-	}
+    dynamicPage(name: "connectionPage", title: "Connection Properties", install: false, uninstall: false) {
+        section {
+            input "prefDatabaseHost", "text", title: "Host", defaultValue: "192.168.1.100", required: true
+            input "prefDatabaseTls", "bool", title:"Use TLS?", defaultValue: false, required: true
+            input "prefDatabasePort", "text", title: "Port", defaultValue: prefDatabaseTls?"443":"8086", required: false
+            input (
+                name: "prefInfluxVer",
+                title: "Influx Version",
+                type: "enum",
+                options: [
+                    "1" : "v1.x",
+                    "2" : "v2.x"
+                ],
+                defaultValue: "1",
+                submitOnChange: true,
+                required: true
+            )
+            if (prefInfluxVer == "1") {
+                input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
+            } else if (prefInfluxVer == "2") {
+                input "prefBucket", "text", title: "Bucket", defaultValue: "", required: true
+            }
+            input (
+                name: "prefAuthType",
+                title: "Authorization Type",
+                type: "enum",
+                options: [
+                    "none" : "None",
+                    "basic" : "Username / Password",
+                    "token" : "Token"
+                ],
+                defaultValue: "basic",
+                submitOnChange: true,
+                required: true
+            )
+            if (prefAuthType == "basic") {
+                input "prefDatabaseUser", "text", title: "Username", defaultValue: "", required: false
+                input "prefDatabasePass", "text", title: "Password", defaultValue: "", required: false
+            } else if (prefAuthType == "token") {
+                input "prefDatabaseToken", "text", title: "Token", required: true
+            }
+        }
+    }
 }
 
 def getDeviceObj(id) {
-	def found
-	settings.allDevices.each { device ->
-	if (device.getId() == id) {
+    def found
+    settings.allDevices.each { device ->
+        if (device.getId() == id) {
             //log.debug "Found at $device for $id with id: ${device.id}"
-		found = device
-		}
-	}
-	return found
+            found = device
+        }
+    }
+    return found
 }
 
 

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -209,6 +209,7 @@ def connectionPage() {
                 title: "Authorization Type",
                 type: "enum",
                 options: [
+					"none" : "None",
                     "basic" : "Username / Password",
                     "token" : "Token"
                 ],

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -189,6 +189,7 @@ def connectionPage() {
             if (prefInfluxVer == "1") {
                 input "prefDatabaseName", "text", title: "Database Name", defaultValue: "Hubitat", required: true
             } else if (prefInfluxVer == "2") {
+                input "prefOrg", "text", title: "Org", defaultValue: "", required: true
                 input "prefBucket", "text", title: "Bucket", defaultValue: "", required: true
             }
             input (


### PR DESCRIPTION
The first set of changes start out by modifying the ui of the app. This is needed as we need to enable the ability to select what version of Influxdb a user is using and then in turn what version of authentication a user will use. To do this we first declare two pages for the setup. The initial page which used a non-descriptive title is was updated to "setupMain" and a second new page labeled "connectionPage"

The "setupMain" page was updated to remove the configuration options for the database and had a link added to load the "connectionPage"

The "connectionPage" allows for selecting between the various options needed between InfluxDB1.x and InfluxDB2.x

The second group of updates where to the update() method Database config section. This section was update to account for the configuration values added to handle InfluxDB2.x. Along with that there was code added to handle building the URL string and header packages needed depending on what version of influxdb the user is running.

The last update was to the postToInfluxDb method to handle the difference that may occur between influxdb versions. The code that was in place for the URI value for Influxdb1.x was hard coded to much and not usable with 2.x. It was updated to use a URI variable that is built in the update method mentioned above. 