### PR TITLE
Added write queue depth value

### DIFF
--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -125,7 +125,7 @@ def setupMain() {
                 input "phMeters", "capability.pHMeasurement", title: "pH Meters", multiple: true, required: false
                 input "powerMeters", "capability.powerMeter", title: "Power Meters", multiple: true, required: false
                 input "presences", "capability.presenceSensor", title: "Presence Sensors", multiple: true, required: false
-                input "pressures", "capability.sensor", title: "Pressure Sensors", multiple: true, required: false
+                input "pressures", "capability.pressureMeasurement", title: "Pressure Sensors", multiple: true, required: false
                 input "shockSensors", "capability.shockSensor", title: "Shock Sensors", multiple: true, required: false
                 input "signalStrengthMeters", "capability.signalStrength", title: "Signal Strength Meters", multiple: true, required: false
                 input "sleepSensors", "capability.sleepSensor", title: "Sleep Sensors", multiple: true, required: false

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -89,7 +89,7 @@ def setupMain() {
             input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
                 options: ["1",  "2", "3", "4", "5", "10", "15"]
             
-            input "prefWriteIntervalQue", "number", title:"Write Interval Queue Size", defaultValue: 50, required: true
+            input "prefWriteQueueLimit", "number", title:"Write Interval Queue Size Limit", defaultValue: 50, required: true
         }
 
         section("System Monitoring:") {
@@ -733,13 +733,7 @@ def queueToInfluxDb(data) {
     finally {
         mutex.release()
     }
-    if (settings.prefWriteIntervalQue == null) {
-        if (queueSize > 100) {
-            logger("Queue size is too big, triggering write now", "info")
-            writeQueuedDataToInfluxDb()
-        }
-    }
-    else if (queueSize > settings.prefWriteIntervalQue) {
+    if (queueSize > (settings.prefWriteQueueLimit ?: 100)) {
         logger("Queue size is too big, triggering write now", "info")
         writeQueuedDataToInfluxDb()
     }

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -88,6 +88,8 @@ def setupMain() {
 
             input "writeInterval", "enum", title:"How often to write to db (minutes)", defaultValue: "5", required: true,
                 options: ["1",  "2", "3", "4", "5", "10", "15"]
+            
+            input "prefWriteIntervalQue", "number", title:"Write Interval Queue Size", defaultValue: 50, required: true
         }
 
         section("System Monitoring:") {
@@ -731,8 +733,13 @@ def queueToInfluxDb(data) {
     finally {
         mutex.release()
     }
-
-    if (queueSize > 100) {
+    if (settings.prefWriteIntervalQue == null) {
+        if (queueSize > 100) {
+            logger("Queue size is too big, triggering write now", "info")
+            writeQueuedDataToInfluxDb()
+        }
+    }
+    else if (queueSize > settings.prefWriteIntervalQue) {
         logger("Queue size is too big, triggering write now", "info")
         writeQueuedDataToInfluxDb()
     }


### PR DESCRIPTION
This is a simple update to make the write queue customizable

1. Add a setting value that will allow for setting a write depth for the queue
2. Add a check for a null value for the new setting value to ensure backwards compatibility
3. Add the new setting value into the  comparison to initiate a forced write when the queue is full

One thing of note is the default value for the setting is 50 in this update. Further investigation may be needed to tweak this value.