### PR TITLE
App multi-instance support

### DIFF
--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -87,7 +87,7 @@ def setupMain() {
 
         }
 
-        section("Change Application Name (optional)"){
+        section("Change Application Name"){
             input "nameOverride", "text", title: "New Name for Application", multiple: false, required: false, submitOnChange: true, defaultValue: app.getLabel()
             if(nameOverride != app.getLabel) app.updateLabel(nameOverride)
         }

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -85,6 +85,12 @@ def setupMain() {
                 displayDuringSetup: true,
                 required: false
             )
+
+        }
+
+        section("Change Application Name (optional)"){
+            input "nameOverride", "text", title: "New Name for Application", multiple: false, required: false, submitOnChange: true, defaultValue: app.getLabel()
+            if(nameOverride != app.getLabel) app.updateLabel(nameOverride)
         }
 
         section("Polling / Write frequency:") {

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -700,8 +700,8 @@ def queueToInfluxDb(data) {
         queueSize = myLoggerQueue.size()
     }
     catch (e) {
-        logger("Error 2 in queueToInfluxDb", "Warning")
-        logger("${e.toString()}","Warning")
+        logger("Error 2 in queueToInfluxDb", "warn")
+        logger("${e.toString()}","warn")
     }
     finally {
         myMutex.release()
@@ -731,8 +731,8 @@ def writeQueuedDataToInfluxDb() {
         myLoggerQueue.clear()
     }
     catch (e) {
-        logger("Error 2 in writeQueuedDataToInfluxDb", "Warning")
-        logger("${e.toString()}","Warning")
+        logger("Error 2 in writeQueuedDataToInfluxDb", "warn")
+        logger("${e.toString()}","warn")
     }
     finally {
         myMutex.release()
@@ -987,8 +987,8 @@ private getLoggerQueue() {
             //logger("Allocated new logger queue for app ${app.getId()}", "Trace")
         }
         catch (e) {
-            logger("Error in getLoggerQueue", "Warning")
-            logger("${e.toString()}","Warning")
+            logger("Error in getLoggerQueue", "warn")
+            logger("${e.toString()}","warn")
         }
         finally {
             myMutex.release()
@@ -1009,14 +1009,14 @@ private releaseLoggerQueue()
         myLoggerQueue = loggerQueueMap.get(app.getId())
         if (myLoggerQueue.size()) {
             // shouldn't happen since we flushed above and there are no async inputs to queue, only async reads/flush.
-            logger("releaseLoggerQueue: queue not empty, size=${myLoggerQueue.size()}", "Warning")
+            logger("releaseLoggerQueue: queue not empty, size=${myLoggerQueue.size()}", "warn")
         }
         // release queue for this app ID
         loggerQueueMap.remove(app.getId())
     }
     catch (e) {
-        logger("Error in releaseLoggerQueue", "Warning")
-        logger("${e.toString()}","Warning")
+        logger("Error in releaseLoggerQueue", "warn")
+        logger("${e.toString()}","warn")
     }
     finally {
         myMutex.release()
@@ -1025,5 +1025,5 @@ private releaseLoggerQueue()
     // release mutex for this app ID
     mutexMap.remove(app.getId())
 
-    logger("released queue/mutex objects for app id ${app.getId()}", "Info")
+    logger("released queue/mutex objects for app id ${app.getId()}", "info")
 }


### PR DESCRIPTION
Added section to allow renaming the app, to make management of multiple instances easier.  Different instances of the app can be necessary to log to different buckets, for example, or to turn off polling on some sensors.

Thread safety : changed @Field static variables to a Map type so that each app ID can have its own queue (and mutex)

Added parsing of "valve" event type to handleEvent() (works just like a switch)