### PR TITLE
filterEvents option control for subscribe()

### DIFF
--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -175,7 +175,7 @@ def setupMain() {
         }
 
         section("Event Subscription Options:") {
-            input "filterEvents", "bool", title:"Filter Events (true = only when value changes)?", defaultValue: true, required: true, submitOnChange: true
+            input "filterEvents", "bool", title:"Only log events when the value changes", defaultValue: true, required: true, submitOnChange: true
         }
 
     }

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -175,7 +175,7 @@ def setupMain() {
         }
 
         section("Event Subscription Options:") {
-            input "filterEvents", "bool", title:"Filter Events (true = only when value changes)?", defaultValue: false, required: true, submitOnChange: true
+            input "filterEvents", "bool", title:"Filter Events (true = only when value changes)?", defaultValue: true, required: true, submitOnChange: true
         }
 
     }

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -173,6 +173,11 @@ def setupMain() {
                 }
             }
         }
+
+        section("Event Subscription Options:") {
+            input "filterEvents", "bool", title:"Filter Events (true = only when value changes)?", defaultValue: false, required: true, submitOnChange: true
+        }
+
     }
 }
 
@@ -875,7 +880,7 @@ private manageSubscriptions() {
                 da.attributes.each { attr ->
                     logger("manageSubscriptions(): Subscribing to attribute: ${attr}, for devices: ${da.devices}", "info")
                     // There is no need to check if all devices in the collection have the attribute.
-                    subscribe(devs, attr, handleEvent)
+                    subscribe(devs, attr, handleEvent, ["filterEvents": filterEvents ])
                 }
             }
         }
@@ -884,7 +889,7 @@ private manageSubscriptions() {
             d = getDeviceObj(entry.key)
             entry.value.each { attr ->
                 logger("manageSubscriptions(): Subscribing to attribute: ${attr}, for device: ${d}", "info")
-                subscribe(d, attr, handleEvent)
+                subscribe(d, attr, handleEvent, ["filterEvents": filterEvents ])
             }
         }
     }


### PR DESCRIPTION
add an option to control whether attribute events where the value is not changed are filtered or not.  Default = not filtered (possibly a breaking change, but I think it's the right choice in general)

Necessary to not filter events with no value change for devices where the last value represents the average of the time period since the previous value.  This is necessary for correct "step-back interpolation", e.g. flow sensors.