### PR TITLE
Fix event timestamping

### DIFF
--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -345,9 +345,8 @@ def handleModeEvent(evt) {
 
     def locationName = escapeStringForInfluxDB(location.name)
     def mode = '"' + escapeStringForInfluxDB(evt.value) + '"'
-    def data = "_stMode,locationName=${locationName} mode=${mode}"
-    long eventTimestamp = evt.unixTime * 1e6 // Time is in milliseconds, needs to be in nanoseconds
-    data += " ${eventTimestamp}"
+    long eventTimestamp = evt.unixTime * 1e6       // Time is in milliseconds, but InfluxDB expects nanoseconds
+    def data = "_stMode,locationName=${locationName} mode=${mode} ${eventTimestamp}"
     queueToInfluxDb(data)
 }
 

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -570,7 +570,7 @@ def handleEvent(evt) {
 
     // add event timestamp
     long eventTimestamp = evt?.unixTime * 1e6   // Time is in milliseconds, InfluxDB expects nanoseconds
-    data += " ${dataTimestamp}"
+    data += " ${eventTimestamp}"
 
     // Queue data for later write to InfluxDB
     //logger("$data", "info")

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -599,6 +599,7 @@ def softPoll() {
     logSystemProperties()
 
     long timeNow = (new Date().time) * 1e6 // Time is in milliseconds, needs to be in nanoseconds
+    logger("softPoll() : current time is ${timeNow}","Trace")
 
     if (!accessAllAttributes) {
         // Iterate over each attribute for each device, in each device collection in deviceAttributes:
@@ -696,10 +697,6 @@ def logSystemProperties() {
 }
 
 def queueToInfluxDb(data) {
-    // Add timestamp (influxdb does this automatically, but since we're batching writes, we need to add it
-    //long timeNow = (new Date().time) * 1e6 // Time is in milliseconds, needs to be in nanoseconds
-    //data += " ${timeNow}"
-
     int queueSize = 0
     try {
         mutex.acquire()

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -346,6 +346,8 @@ def handleModeEvent(evt) {
     def locationName = escapeStringForInfluxDB(location.name)
     def mode = '"' + escapeStringForInfluxDB(evt.value) + '"'
     def data = "_stMode,locationName=${locationName} mode=${mode}"
+    long eventTimestamp = evt.unixTime * 1e6 // Time is in milliseconds, needs to be in nanoseconds
+    data += " ${eventTimestamp}"
     queueToInfluxDb(data)
 }
 
@@ -567,8 +569,13 @@ def handleEvent(evt) {
         data += ",unit=${unit} value=${value}"
     }
 
+    // add event timestamp
+    long eventTimestamp = evt.unixTime * 1e6 // Time is in milliseconds, needs to be in nanoseconds
+    data += " ${eventTimestamp}"
+
     // Queue data for later write to InfluxDB
     //logger("$data", "info")
+
     queueToInfluxDb(data)
 }
 
@@ -590,6 +597,9 @@ def softPoll() {
     logger("softPoll()", "trace")
 
     logSystemProperties()
+
+    long timeNow = (new Date().time) * 1e6 // Time is in milliseconds, needs to be in nanoseconds
+
     if (!accessAllAttributes) {
         // Iterate over each attribute for each device, in each device collection in deviceAttributes:
         def devs // temp variable to hold device collection.
@@ -608,7 +618,8 @@ def softPoll() {
                                 unit: d.latestState(attr)?.unit,
                                 device: d,
                                 deviceId: d.id,
-                                displayName: d.displayName
+                                displayName: d.displayName,
+                                unixTime: timeNow
                             ])
                         }
                     }
@@ -628,7 +639,8 @@ def softPoll() {
                         unit: d.latestState(attr)?.unit,
                         device: d,
                         deviceId: d.id,
-                        displayName: d.displayName
+                        displayName: d.displayName,
+                        unixTime: timeNow
                     ])
                 }
             }
@@ -645,6 +657,7 @@ def logSystemProperties() {
     logger("logSystemProperties()", "trace")
 
     def locationName = '"' + escapeStringForInfluxDB(location.name) + '"'
+    long timeNow = (new Date().time) * 1e6 // Time is in milliseconds, needs to be in nanoseconds
 
     // Location Properties:
     if (prefLogLocationProperties) {
@@ -655,7 +668,7 @@ def logSystemProperties() {
             def srt = '"' + times.sunrise.format("HH:mm", location.timeZone) + '"'
             def sst = '"' + times.sunset.format("HH:mm", location.timeZone) + '"'
 
-            def data = "_heLocation,locationName=${locationName},latitude=${location.latitude},longitude=${location.longitude},timeZone=${tz} mode=${mode},sunriseTime=${srt},sunsetTime=${sst}"
+            def data = "_heLocation,locationName=${locationName},latitude=${location.latitude},longitude=${location.longitude},timeZone=${tz} mode=${mode},sunriseTime=${srt},sunsetTime=${sst} ${timeNow}"
             queueToInfluxDb(data)
             //log.debug("LocationData = ${data}")
         } catch (e) {
@@ -672,7 +685,7 @@ def logSystemProperties() {
                 def firmwareVersion =  '"' + escapeStringForInfluxDB(h.firmwareVersionString) + '"'
 
                 def data = "_heHub,locationName=${locationName},hubName=${hubName},hubIP=${hubIP} "
-                data += "firmwareVersion=${firmwareVersion}"
+                data += "firmwareVersion=${firmwareVersion} ${timeNow}"
                 //log.debug("HubData = ${data}")
                 queueToInfluxDb(data)
             } catch (e) {
@@ -684,8 +697,8 @@ def logSystemProperties() {
 
 def queueToInfluxDb(data) {
     // Add timestamp (influxdb does this automatically, but since we're batching writes, we need to add it
-    long timeNow = (new Date().time) * 1e6 // Time is in milliseconds, needs to be in nanoseconds
-    data += " ${timeNow}"
+    //long timeNow = (new Date().time) * 1e6 // Time is in milliseconds, needs to be in nanoseconds
+    //data += " ${timeNow}"
 
     int queueSize = 0
     try {

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -569,15 +569,7 @@ def handleEvent(evt) {
     }
 
     // add event timestamp
-    long dataTimestamp
-    eventTimestamp = evt?.unixTime
-    if (eventTimestamp) {
-        dataTimestamp = eventTimestamp
-    } else {
-        // create a data timestamp if it is missing from the event (for backward compat)
-        dataTimestamp = new Date().time
-    }
-    dataTimestamp *= 1e6   // Time is in milliseconds, InfluxDB expects nanoseconds
+    long eventTimestamp = evt?.unixTime * 1e6   // Time is in milliseconds, InfluxDB expects nanoseconds
     data += " ${dataTimestamp}"
 
     // Queue data for later write to InfluxDB

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -570,8 +570,16 @@ def handleEvent(evt) {
     }
 
     // add event timestamp
-    long eventTimestamp = evt.unixTime * 1e6 // Time is in milliseconds, needs to be in nanoseconds
-    data += " ${eventTimestamp}"
+    long dataTimestamp
+    eventTimestamp = evt?.unixTime
+    if (eventTimestamp) {
+        dataTimestamp = eventTimestamp
+    } else {
+        // create a data timestamp if it is missing from the event (for backward compat)
+        dataTimestamp = new Date().time
+    }
+    dataTimestamp *= 1e6   // Time is in milliseconds, InfluxDB expects nanoseconds
+    data += " ${dataTimestamp}"
 
     // Queue data for later write to InfluxDB
     //logger("$data", "info")

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -598,9 +598,6 @@ def softPoll() {
 
     logSystemProperties()
 
-    long timeNow = (new Date().time) * 1e6 // Time is in milliseconds, needs to be in nanoseconds
-    logger("softPoll() : current time is ${timeNow}","Trace")
-
     if (!accessAllAttributes) {
         // Iterate over each attribute for each device, in each device collection in deviceAttributes:
         def devs // temp variable to hold device collection.
@@ -611,8 +608,8 @@ def softPoll() {
                     da.attributes.each { attr ->
                         if (d.hasAttribute(attr) && d.latestState(attr)?.value != null) {
                             logger("softPoll(): Softpolling device ${d} for attribute: ${attr}", "info")
+                            long timeNow = new Date().time
                             // Send fake event to handleEvent():
-
                             handleEvent([
                                 name: attr,
                                 value: d.latestState(attr)?.value,
@@ -633,6 +630,7 @@ def softPoll() {
             entry.value.each { attr ->
                 if (d.hasAttribute(attr) && d.latestState(attr)?.value != null) {
                     logger("softPoll(): Softpolling device ${d} for attribute: ${attr}", "info")
+                    long timeNow = new Date().time
                     // Send fake event to handleEvent():
                     handleEvent([
                         name: attr,
@@ -658,7 +656,7 @@ def logSystemProperties() {
     logger("logSystemProperties()", "trace")
 
     def locationName = '"' + escapeStringForInfluxDB(location.name) + '"'
-    long timeNow = (new Date().time) * 1e6 // Time is in milliseconds, needs to be in nanoseconds
+    long timeNow = (new Date().time) * 1e6 // Time is in milliseconds, needs to be in nanoseconds when pushed to InfluxDB
 
     // Location Properties:
     if (prefLogLocationProperties) {


### PR DESCRIPTION
Events carry a timestamp property (unixTime).  The current code disregards the event timestamp (presumably set at the time the event is published or the attribute update recorded) and generates one itself at the time of event processing.  Not a huge difference in most cases, but that difference can change the order in which events are seen to happen when processing in InfluxDB or Grafana.

- When a real event is logged, use the event's timestamp.
- When a fake event is logged (soft polling, hub properties, local properties), generate a timestamp with Date().time.