### PR TITLE
add error message to log when http response >= 400 returned

### DIFF
--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -773,7 +773,7 @@ def postToInfluxDB(data) {
 def handleInfluxResponse(hubResponse, data) {
     //logger("postToInfluxDB(): status of post call is: ${hubResponse.status}", "info")
     if (hubResponse.status >= 400) {
-        logger("postToInfluxDB(): Something went wrong! Response from InfluxDB: Status: ${hubResponse.status}, Headers: ${hubResponse.headers}, Data: ${data}", "error")
+        logger("postToInfluxDB(): Something went wrong! Response from InfluxDB: Status: ${hubResponse.status}, Error: ${hubResponse.errorMessage}, Headers: ${hubResponse.headers}, Data: ${data}", "error")
     }
 }
 
@@ -958,4 +958,3 @@ private String escapeStringForInfluxDB(String str) {
     }
     return str
 }
-


### PR DESCRIPTION
as documented here https://community.hubitat.com/t/async-http-calls/1694

was getting sporadic 408's and the error message text was actually helpful.