### PR TITLE
Add capability to subscribe to Hubitat variables

### DIFF
--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -377,7 +377,6 @@ void uninstalled() {
  *  Runs when app settings are changed.
  **/
 void updated() {
-    softPoll()
     // Update application name
     app.updateLabel(settings.appName)
     logger("${app.label}: Updated", logInfo)

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -953,7 +953,6 @@ List<String> getVariableEventList() {
             unixTime: timeNow
         ])
         eventList.add(event)
-        logger("${variable.value}", logError)
     }
 
     // Return the events

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -407,7 +407,7 @@ void updated() {
     // Subscribe to variables
     (booleanVariables+numberVariables+decimalVariables+stringVariables+datetimeVariables).each { name ->
         subscribe(location, "variable:" + name, handleVariableEvent)
-        logger("Subscribing to variable ${name}", logInfo) // TODO: change back to Info
+        logger("Subscribing to variable ${name}", logInfo)
     }
 
     // Clear out any prior schedules

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -753,8 +753,6 @@ private String encodeVariableEvent(evt) {
         measurement = "binaryVariable"
         value = evt.value
         valueBinary = (evt.value == "true") ? '1i' : '0i'
-        logger("${evt.value}", logError)
-        logger("${evt.value == "true"}", logError)
     }
     else if (numberVariables.contains(variableName)){
         measurement = "numberVariable"

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -401,11 +401,19 @@ void updated() {
 
     // Subscribe to mode events if requested
     if (prefPostHubInfo) {
-        subscribe(location, "mode", handleModeEvent)
+        subscribe(location, "mode", handleModeEvent, ["filterEvents": filterEvents])
     }
     
     // Subscribe to variables
-    (booleanVariables+numberVariables+decimalVariables+stringVariables+datetimeVariables).each { name ->
+    String<List> subscribedVariables = []
+    
+    if (booleanVariables) { subscribedVariables += booleanVariables }
+    if (numberVariables) { subscribedVariables += numberVariables }
+    if (decimalVariables) { subscribedVariables += decimalVariables }
+    if (stringVariables) { subscribedVariables += stringVariables }
+    if (datetimeVariables) { subscribedVariables += datetimeVariables }
+    
+    subscribedVariables.each { name ->
         subscribe(location, "variable:" + name, handleVariableEvent)
         logger("Subscribing to variable ${name}", logInfo)
     }

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -401,19 +401,11 @@ void updated() {
 
     // Subscribe to mode events if requested
     if (prefPostHubInfo) {
-        subscribe(location, "mode", handleModeEvent, ["filterEvents": filterEvents])
+        subscribe(location, "mode", handleModeEvent)
     }
 
     // Subscribe to variables
-    String<List> subscribedVariables = []
-
-    if (booleanVariables) { subscribedVariables += booleanVariables }
-    if (numberVariables) { subscribedVariables += numberVariables }
-    if (decimalVariables) { subscribedVariables += decimalVariables }
-    if (stringVariables) { subscribedVariables += stringVariables }
-    if (datetimeVariables) { subscribedVariables += datetimeVariables }
-
-    subscribedVariables.each { name ->
+    (booleanVariables + numberVariables + decimalVariables + stringVariables + datetimeVariables).each { name ->
         subscribe(location, "variable:" + name, handleVariableEvent, ["filterEvents": filterEvents])
         logger("Subscribing to variable ${name}", logInfo)
     }

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -269,35 +269,35 @@ def setupMain() {
                 }
             }
         }
-        
-        section("Variables To Monitor:", hideable:true, hidden:false) {    
+
+        section("Variables To Monitor:", hideable:true, hidden:false) {
             input "booleanVariables", "enum", title: "Select Boolean Variables", multiple: true, submitOnChange: true,
-                options: getAllGlobalVars().findAll{
+                options: getAllGlobalVars().findAll {
                     it.value.type == "boolean"
-                }.keySet().collect().sort{it.capitalize()}
+                }.keySet().collect().sort { it.capitalize() }
 
             input "numberVariables", "enum", title: "Select Number Variables", multiple: true, submitOnChange: true,
-                options: getAllGlobalVars().findAll{
+                options: getAllGlobalVars().findAll {
                     it.value.type == "integer"
-                }.keySet().collect().sort{it.capitalize()}
+                }.keySet().collect().sort { it.capitalize() }
 
             input "decimalVariables", "enum", title: "Select Decimal Variables", multiple: true, submitOnChange: true,
-                options: getAllGlobalVars().findAll{
+                options: getAllGlobalVars().findAll {
                     it.value.type == "bigdecimal"
-                }.keySet().collect().sort{it.capitalize()}
+                }.keySet().collect().sort { it.capitalize() }
 
             input "stringVariables", "enum", title: "Select String Variables", multiple: true, submitOnChange: true,
-                options: getAllGlobalVars().findAll{
+                options: getAllGlobalVars().findAll {
                     it.value.type == "string"
-                }.keySet().collect().sort{it.capitalize()}
-            
+                }.keySet().collect().sort { it.capitalize() }
+
             input "datetimeVariables", "enum", title: "Select DateTime Variables", multiple: true, submitOnChange: true,
-                options: getAllGlobalVars().findAll{
+                options: getAllGlobalVars().findAll {
                     it.value.type == "datetime"
-                }.keySet().collect().sort{it.capitalize()}
-        }
-    }
-}
+                }.keySet().collect().sort { it.capitalize() }
+                }
+                }
+                }
 
 def connectionPage() {
     dynamicPage(name: "connectionPage", title: "Connection Properties", install: false, uninstall: false) {
@@ -403,18 +403,18 @@ void updated() {
     if (prefPostHubInfo) {
         subscribe(location, "mode", handleModeEvent, ["filterEvents": filterEvents])
     }
-    
+
     // Subscribe to variables
     String<List> subscribedVariables = []
-    
+
     if (booleanVariables) { subscribedVariables += booleanVariables }
     if (numberVariables) { subscribedVariables += numberVariables }
     if (decimalVariables) { subscribedVariables += decimalVariables }
     if (stringVariables) { subscribedVariables += stringVariables }
     if (datetimeVariables) { subscribedVariables += datetimeVariables }
-    
+
     subscribedVariables.each { name ->
-        subscribe(location, "variable:" + name, handleVariableEvent)
+        subscribe(location, "variable:" + name, handleVariableEvent, ["filterEvents": filterEvents])
         logger("Subscribing to variable ${name}", logInfo)
     }
 
@@ -749,7 +749,6 @@ private String encodeDeviceEvent(evt) {
  *   - Interprets binary variables to write to valueBinary
  **/
 private String encodeVariableEvent(evt) {
-
     String variableName = evt.name.substring(9)
 
     String variableNameEscaped = escapeStringForInfluxDB(variableName)
@@ -762,22 +761,22 @@ private String encodeVariableEvent(evt) {
         value = evt.value
         valueBinary = Boolean.valueOf(evt.value) ? '1i' : '0i'
     }
-    else if (numberVariables.contains(variableName)){
+    else if (numberVariables.contains(variableName)) {
         measurement = "numberVariable"
         value = evt.value
     }
-    else if (decimalVariables.contains(variableName)){
+    else if (decimalVariables.contains(variableName)) {
         measurement = "decimalVariable"
         value = evt.value
     }
-    else if (stringVariables.contains(variableName)){
+    else if (stringVariables.contains(variableName)) {
         measurement = "stringVariable"
         value = '"' + escapeStringForInfluxDB(evt.value) + '"'
     }
-    else if (datetimeVariables.contains(variableName)){
+    else if (datetimeVariables.contains(variableName)) {
         measurement = "datetimeVariable"
         String datetime = evt.value
-        String[] datetimeSplitted = datetime.split(' ');
+        String[] datetimeSplitted = datetime.split(' ')
         value = '"' + escapeStringForInfluxDB(evt.value) + '"'
     }
 
@@ -940,11 +939,10 @@ void softPoll() {
 /**
  *  getVariableEventList()
  *
- *  Polls all variables on the hub, read the variables that InfluxDB logger is tracking, 
+ *  Polls all variables on the hub, read the variables that InfluxDB logger is tracking,
  *  and create events to be queued to write to InfluxDB.
  **/
 List<String> getVariableEventList() {
-
     // Get all variables
     Map<String,Map<String,String>> allVariables = getAllGlobalVars()
 
@@ -959,7 +957,7 @@ List<String> getVariableEventList() {
     if (decimalVariables) { subscribedVariables += decimalVariables }
     if (stringVariables) { subscribedVariables += stringVariables }
     if (datetimeVariables) { subscribedVariables += datetimeVariables }
-        
+
     subscribedVariables.each { name ->
         Map<String, String> variable = allVariables[name]
         String event = encodeVariableEvent([

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -972,7 +972,7 @@ private void queueToInfluxDb(List<String> eventList) {
         // Failsafe if coming from an old version
         state.loggerQueue = []
     }
-    
+
     // Add the data to the queue
     priorLoggerQueueSize = state.loggerQueue.size()
     state.loggerQueue += eventList

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -454,7 +454,7 @@ void updated() {
     state.remove("writeInterval")
     app.removeSetting("prefLogHubProperties")
     app.removeSetting("prefLogLocationProperties")
-    app.removeSetting("prefLogModeEvents")   
+    app.removeSetting("prefLogModeEvents")
 }
 
 /**

--- a/influxdb-logger.groovy
+++ b/influxdb-logger.groovy
@@ -78,6 +78,7 @@
  *   2023-03-18 Denny Page      Fix valve attribute
  *                              Clean up logging
  *   2023-04-24 Denny Page      Don't send null units to InfluxDB
+ *   2023-07-15 Scott Chen      Support hub variables
  *****************************************************************************************************************/
 
 // Note: Items marked as "Migration" are intended to be kept for a period of time and then be removed circa end of 2023


### PR DESCRIPTION
This PR adds the following functionality to allow the user to subscribe to hub variables and write to InfluxDB.
- Add new UI section: "Variables To Monitor" that allows users to select Boolean, Decimal, Number, DateTime, and String variables.
- Add logic to subscribe to variables through the UI and handle the incoming events through handleVariableEvent.
- Add encodeVariableEvent analogous to encodeDeviceEvent that encodes variable events and values into InfluxDB formats.
- Add getVariableEventList analogous to softPoll, without the capability to check for changes. getVariableEventList will always do a hard poll for all variables tracked.